### PR TITLE
fix yarg discord link and !archive not working

### DIFF
--- a/triggers.json
+++ b/triggers.json
@@ -241,7 +241,7 @@
     },
     "response49": {
         "triggers": ["yarg"],
-        "text": "Also try YARG, a Rock Band inspired Unity based rhythm game!\nhttps://discord.gg/yarg\nhttps://yarg.in",
+        "text": "Also try YARG, a Rock Band inspired Unity based rhythm game!\nhttps://discord.gg/sqpu4R552r\nhttps://yarg.in",
         "files": []
     },
     "response50": {
@@ -565,7 +565,7 @@
         "text": "Want to learn more about Harmonix games? Check out the [[Archive]](https://docs.google.com/spreadsheets/d/1nMnaiGtHLin-BVsBqc7_vNysCui0jy8oYY-UICtHidg/)",
         "files": []
     },
-    "response113": {
+    "response114": {
         "triggers": ["defaultdance", "chasedance"],
         "text": "",
         "files": ["media/defaultdance.mp4"]


### PR DESCRIPTION
YARG doesn't have boost level 3 atm, so the vanity link doesn't work. Grabbed a new link from #rules-and-info in the YARG discord.

Also, !archive and !defaultdance used duplicate response numbers, so that is now fixed.
